### PR TITLE
Dev aof

### DIFF
--- a/appendonly.aof
+++ b/appendonly.aof
@@ -1,0 +1,1 @@
+set test 1

--- a/lib/redis/core/client.go
+++ b/lib/redis/core/client.go
@@ -17,5 +17,6 @@ type RedisClient struct {
 	RawReq   string       // 从客户端收到的原始请求
 	ReqValue *resp3.Value // 从客户端收到的请求
 
-	Flags int //处理标记
+	Flags int  //处理标记
+	IsAOF bool //是否为AOF虚拟客户端
 }

--- a/lib/redis/io/cmd.go
+++ b/lib/redis/io/cmd.go
@@ -3,6 +3,7 @@ package io
 import (
 	"errors"
 	"redis-go/lib/redis/core"
+	"redis-go/lib/redis/resistence"
 	"redis-go/lib/redis/shared"
 	"strings"
 
@@ -47,6 +48,11 @@ func ProcessCommand(client *core.RedisClient) (err error) {
 	if client.Cmd == nil {
 		log.Warn().Str("addr", client.Conn.RemoteAddr().String()).Str("command", cmd).Msg("not found")
 		return errCommandUnknown
+	}
+
+	// 检查是否需要持久化该命令
+	if resistence.NeedAOF(cmd) {
+		resistence.AddToAOFBuffer(client.ReqValue)
 	}
 
 	return call(client, 0)

--- a/lib/redis/io/reply.go
+++ b/lib/redis/io/reply.go
@@ -63,6 +63,9 @@ func AddReplyObject(client *core.RedisClient, obj *core.Object) {
 
 // SendReplyToClient 向客户端发送一个已经构造为resp3.Value的值
 func SendReplyToClient(client *core.RedisClient, value *resp3.Value) {
+	if client.IsAOF {
+		return
+	}
 	s := value.ToRESP3String()
 	SendRawReplyToClient(client, []byte(s))
 }

--- a/lib/redis/redis.go
+++ b/lib/redis/redis.go
@@ -1,9 +1,11 @@
 package redis
 
 import (
+	"fmt"
 	"os"
 	"redis-go/lib/redis/core"
 	"redis-go/lib/redis/io"
+	"redis-go/lib/redis/resistence"
 	"redis-go/lib/redis/set"
 	"redis-go/lib/redis/shared"
 	"redis-go/lib/redis/str"
@@ -114,6 +116,15 @@ func Start() {
 
 	initServerConfig()
 	initServer()
+
+	if err := resistence.LoadAOF("appendonly.aof"); err != nil {
+		fmt.Println("Failed to load AOF: %v", err)
+	}
+
+	if err := resistence.InitAOF("appendonly.aof"); err != nil {
+		fmt.Println("Failed to initialize AOF: %v", err)
+	}
+
 	elMain()
 }
 

--- a/lib/redis/resistence/aof.go
+++ b/lib/redis/resistence/aof.go
@@ -37,9 +37,21 @@ var aofCommands = map[string]struct{}{
 	"decrby": ept,
 	"append": ept,
 
-	// push
-	"zadd":  ept,
+	// list
 	"lpush": ept,
+	"lpop":  ept,
+	"rpush": ept,
+	"rpop":  ept,
+
+	//set
+	"sadd": ept,
+	"srem": ept,
+
+	//zset
+	"zadd":             ept,
+	"zincrby":          ept,
+	"zrem":             ept,
+	"zremrangebyscore": ept,
 
 	// Add other write-related commands here
 }

--- a/lib/redis/resistence/aof.go
+++ b/lib/redis/resistence/aof.go
@@ -1,0 +1,227 @@
+package resistence
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"os"
+	"redis-go/lib/redis/core"
+	"redis-go/lib/redis/shared"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/cinea4678/resp3"
+)
+
+var (
+	aofFile   *os.File
+	aofMutex  sync.Mutex
+	aofBuffer []string
+)
+
+var (
+	errCommandUnknown = errors.New("command unknown")
+)
+
+// 空白占位符，使用map实现集合
+var ept = struct{}{}
+
+// 记录需要持久化的写指令
+var aofCommands = map[string]struct{}{
+	// str
+	"set":    ept,
+	"incr":   ept,
+	"incrby": ept,
+	"decr":   ept,
+	"decrby": ept,
+	"append": ept,
+
+	// push
+	"zadd":  ept,
+	"lpush": ept,
+
+	// Add other write-related commands here
+}
+
+func NeedAOF(command string) bool {
+	if _, ok := aofCommands[command]; ok {
+		return true
+	}
+	return false
+}
+
+func InitAOF(filePath string) error {
+	var err error
+	aofFile, err = os.OpenFile(filePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return err
+	}
+
+	aofBuffer = make([]string, 0)
+	go flushAOFBufferPeriodically()
+
+	return nil
+}
+
+// parseCommandString 解析命令字符串
+func parseCommandString(commandStr string) (*core.RedisCommand, []string, error) {
+	parts := strings.Fields(commandStr)
+	if len(parts) == 0 {
+		return nil, nil, errCommandUnknown
+	}
+
+	cmdName := strings.ToLower(parts[0])
+	cmd := lookupCommand(cmdName)
+	if cmd == nil {
+		return nil, nil, errCommandUnknown
+	}
+
+	return cmd, parts[1:], nil
+}
+
+func lookupCommand(name string) *core.RedisCommand {
+	name = strings.ToLower(name) // 转换为小写
+	cmd := shared.Server.Commands.DictFind(name)
+	if cmd == nil {
+		return nil
+	}
+	return cmd.(*core.RedisCommand)
+}
+
+// executeCommand 从AOF文件执行命令
+func executeCommand(commandStr string) error {
+	cmd, args, err := parseCommandString(commandStr)
+	if err != nil {
+		return err
+	}
+
+	client := &core.RedisClient{
+		ReqValue: &resp3.Value{
+			Elems: make([]*resp3.Value, len(args)+1),
+		},
+		Db:    shared.Server.Db[0],
+		IsAOF: true,
+	}
+
+	client.ReqValue.Elems[0] = &resp3.Value{Str: cmd.Name}
+	for i, arg := range args {
+		client.ReqValue.Elems[i+1] = &resp3.Value{Str: arg}
+	}
+
+	fmt.Println(cmd)
+	client.Cmd = cmd
+	client.LastCmd = cmd
+
+	return call(client, 0)
+}
+
+func call(client *core.RedisClient, _ int) error {
+	return client.Cmd.RedisClientFunc(client)
+}
+
+func LoadAOF(filePath string) (err error) {
+	file, err := os.Open(filePath)
+	fmt.Println("open AOF file successfully: ", file.Name())
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		command := scanner.Text()
+		fmt.Println("command: ", command)
+		// 执行指令
+		if err := executeCommand(command); err != nil {
+			return err
+		}
+	}
+	return nil
+	// return scanner.Err()
+}
+
+func AddToAOFBuffer(commandValue *resp3.Value) {
+
+	strbuilder := strings.Builder{}
+
+	for _, elem := range commandValue.Elems {
+		cmd := elem.Str + " "
+		strbuilder.WriteString(cmd)
+	}
+
+	command := strings.TrimSpace(strbuilder.String())
+
+	aofMutex.Lock()
+	defer aofMutex.Unlock()
+
+	aofBuffer = append(aofBuffer, command)
+	if len(aofBuffer) >= shared.AOFBuffer { // 缓冲区达到1000条命令时刷新
+		flushAOFBuffer()
+	}
+}
+
+func flushAOFBuffer() (err error) {
+	if len(aofBuffer) == 0 {
+		return
+	}
+
+	for _, command := range aofBuffer {
+		_, err := aofFile.WriteString(command + "\n")
+		if err != nil {
+			return err
+		}
+	}
+
+	aofBuffer = aofBuffer[:0] // Clear the buffer
+	return
+}
+
+func flushAOFBufferPeriodically() (err error) {
+	for {
+		time.Sleep(shared.AOFInterval)
+		aofMutex.Lock()
+		// fmt.Println(aofBuffer)
+		err := flushAOFBuffer()
+		if err != nil {
+			fmt.Println(err)
+		}
+		aofMutex.Unlock()
+	}
+}
+
+func CloseAOF() error {
+	aofMutex.Lock()
+	defer aofMutex.Unlock()
+
+	flushAOFBuffer()
+	return aofFile.Close()
+}
+
+// package resistence
+
+// import (
+// 	"os"
+// 	"sync"
+// )
+
+// var aofFile *os.File
+// var aofMutex sync.Mutex
+
+// func InitAOF(filePath string) error {
+// 	var err error
+// 	aofFile, err = os.OpenFile(filePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+// 	return err
+// }
+
+// func WriteToAOF(command string) error {
+// 	aofMutex.Lock()
+// 	defer aofMutex.Unlock()
+
+// 	_, err := aofFile.WriteString(command + "\n")
+// 	return err
+// }
+
+// func CloseAOF() error {
+// 	return aofFile.Close()
+// }

--- a/lib/redis/shared/const.go
+++ b/lib/redis/shared/const.go
@@ -1,5 +1,7 @@
 package shared
 
+import "time"
+
 // TODO! 可修改为配置文件设定
 
 const (
@@ -9,4 +11,7 @@ const (
 
 	RedisServerPort = 6389
 	RedisTcpBacklog = 511
+
+	AOFInterval = 1 * time.Second // aof间隔时间
+	AOFBuffer   = 1000            //aof缓冲区刷新大小
 )


### PR DESCRIPTION
+ 新增appendonly.aof文件，对需要持久化的语句及参数以字符串形式存储
+ core/client.go:client新增IsAOF字段，如果为true则所有reply都直接return而不实际发送数据（因为持久化的虚拟客户端无连接
+ io/cmd.go:ProcessCommand添加检查语句是否需要持久化，若需要则写入缓冲池
+ replay.go:见上一条
+ redis.go:添加LoadAOF和InitAOF（读取持久化和初始化持久化，新建goroutine每隔一秒进行持久化
+ 新增resistence包+aof.go